### PR TITLE
ci: setup conventional commits pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,11 @@
+name: Conventional Commits
+
+on: [pull_request, push]
+
+jobs:
+  build:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: webiny/action-conventional-commits@v1.1.0


### PR DESCRIPTION
I added a conventional commit check to the CI pipeline as a GitHub Action. I'm using the script from [action-conventional-commits](https://github.com/webiny/action-conventional-commits). The pipeline will probably fail when it gets merged because of "Initial commit". So I will probably have to amend that commit and change the Git history. 